### PR TITLE
Add ticker-based spot price retrieval and exercise date input

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project implements the Black-Scholes Option Pricing Model using Streamlit, 
 - **User-friendly Sidebar**: Input fields to enter the parameters for the Black-Scholes model, including:
   - Current Price
   - Strike Price
-  - Time to Maturity (in years)
+  - Exercise Date (option expiration)
   - Volatility (σ)
   - Risk-Free Interest Rate
 - **Interactive Heatmap Parameters**: Users can specify ranges for spot prices and volatilities to generate heatmaps that visualize how option prices change with these variables.

--- a/black_scholes_app.py
+++ b/black_scholes_app.py
@@ -11,6 +11,8 @@ import pandas as pd
 import plotly.graph_objects as go
 import matplotlib.pyplot as plt
 import seaborn as sns
+import yfinance as yf
+from datetime import date, timedelta
 from black_scholes import BlackScholes
 
 
@@ -67,9 +69,36 @@ with st.sidebar:
     linkedin_url = "https://www.linkedin.com/in/nitishchawla-/"
     st.markdown(f'<a href="{linkedin_url}" target="_blank" style="text-decoration: none; color: inherit;"><img src="https://cdn-icons-png.flaticon.com/512/174/174857.png" width="25" height="25" style="vertical-align: middle; margin-right: 10px;">`Nitish Chawla`</a>', unsafe_allow_html=True)
 
-    current_price = st.number_input("Current Price", min_value=0.0, step=1.0, value=100.0, help="The current market price of the underlying asset.")
-    strike = st.number_input("Strike Price", min_value=0.0, step=1.0, value=100.0, help="The price at which the option can be exercised at maturity.")
-    time_to_maturity = st.number_input("Time to Maturity (Years)", min_value=0.0, step=0.01, value=1.0, help="The time remaining until the option's expiration date, measured in years.")
+    ticker = st.text_input(
+        "Ticker Symbol",
+        value="AAPL",
+        help="Stock ticker used to fetch the current market price",
+    )
+    try:
+        ticker_data = yf.Ticker(ticker)
+        current_price = ticker_data.history(period="1d")["Close"].iloc[-1]
+        st.write(f"Current Price for {ticker}: ${current_price:.2f}")
+    except Exception:
+        current_price = 100.0
+        st.warning(
+            "Unable to fetch price for the ticker. Using default price of $100.0."
+        )
+    strike = st.number_input(
+        "Strike Price",
+        min_value=0.0,
+        step=1.0,
+        value=100.0,
+        help="The price at which the option can be exercised at maturity.",
+    )
+    today = date.today()
+    default_exercise_date = today + timedelta(days=365)
+    exercise_date = st.date_input(
+        "Exercise Date",
+        value=default_exercise_date,
+        min_value=today,
+        help="The option's expiration date.",
+    )
+    time_to_maturity = (exercise_date - today).days / 365
     volatility = st.number_input("Volatility (σ)", min_value=0.0, max_value=1.0, step=0.01, value=0.2, help="The estimated standard deviation of the asset's returns, representing market volatility.")
     interest_rate = st.number_input("Risk-Free Interest Rate", min_value=0.0, max_value=1.0, step=0.01, value=0.05, help="The risk-free interest rate, often based on government bonds, representing the cost of capital.")
 
@@ -118,7 +147,8 @@ st.title("Black-Scholes Option Pricing Model")
 input_data = {
     "Current Price": [current_price],
     "Strike Price": [strike],
-    "Time to Maturity": [time_to_maturity],
+    "Exercise Date": [exercise_date],
+    "Time to Maturity (Years)": [time_to_maturity],
     "Volatility": [volatility],
     "Risk-Free Interest Rate": [interest_rate]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly
 scipy
 matplotlib
 seaborn
+yfinance


### PR DESCRIPTION
## Summary
- fetch current asset price from a user-specified ticker using yfinance
- allow selecting an exercise date to derive time to maturity automatically

## Testing
- `python -m py_compile black_scholes_app.py black_scholes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2680075b0832896f7b2a524ebaf20